### PR TITLE
Remove unnecessary timeseries chart key deletion for charts with > 20 sensors

### DIFF
--- a/bmsapp/reports/timeseries.py
+++ b/bmsapp/reports/timeseries.py
@@ -87,7 +87,6 @@ class TimeSeries(basechart.BaseChart):
         # If there there are more than 20 sensors, hide the legend
         if len(sensor_list) > 20:
             opt['layout']['showlegend'] = False
-            del opt['layout']['margin']['b']
 
         opt['layout']['xaxis']['title'] =  "Date/Time (%s)" % self.timezone
         opt['layout']['xaxis']['type'] =  'date'


### PR DESCRIPTION
Remove map key deletion call when a timeseries chart contains more than 20 sensors.

The default Plotly chart configuration does not contain a 'b' key and attempting to remove that key throws an exception which bubbles up to a generic error message displayed to end users and no chart.